### PR TITLE
PR時の自動テストを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: test-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: cargo test


### PR DESCRIPTION
## 概要

- Pull Requestの作成・更新時に `cargo test` を実行するGitHub Actionsを追加
- ワークフロー権限を `contents: read` に限定
- 同じPRで古い実行が残らないよう、進行中ジョブを自動キャンセル
- ジョブのタイムアウトを10分に設定

## 背景

PRの変更をマージする前にRustテストを自動実行し、リグレッションを検出できるようにします。

Closes #87

## 動作確認

- `cargo test`（81件成功）
- Workflow YAMLの構文確認