### PR TITLE
重要なコンパイラ・MIDIテストを追加

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,13 @@ impl SakuraCompiler {
     }
     /// compile to MIDI data
     pub fn compile(&mut self, source: &str) -> Vec<u8> {
+        // 同じコンパイラを再利用しても、前回の曲やログを引き継がない。
+        self.song = song::Song::new();
+        self.log_str.clear();
+        if self.debug_level > 0 {
+            self.song.debug = true;
+        }
+        self.song.set_language(&self.lang);
         if source.len() > self.max_input_size {
             let msg = format!(
                 "[ERROR](0) Input size exceeds max_input_size ({} > {})",
@@ -82,10 +89,6 @@ impl SakuraCompiler {
             self.log_str.push_str(&log_text);
             return vec![];
         }
-        if self.debug_level > 0 {
-            self.song.debug = true;
-        }
-        self.song.set_language(&self.lang);
         // convert sutoton
         let source_mml = sutoton::convert(source);
         // parse MML
@@ -167,5 +170,48 @@ pub fn compile(source: &str, debug_level: u32) -> SakuraResult {
     SakuraResult {
         bin,
         log: log_text
+    }
+}
+
+#[cfg(test)]
+mod public_api_tests {
+    use super::*;
+
+    #[test]
+    fn compile_returns_midi_data() {
+        let result = compile("o4c", SAKURA_DEBUG_NONE);
+        assert!(result.log.is_empty());
+        assert!(result.bin.starts_with(b"MThd"));
+        assert!(result.bin.ends_with(&[0x00, 0xFF, 0x2F, 0x00]));
+    }
+
+    #[test]
+    fn compiler_can_be_reused_without_mixing_previous_song() {
+        let mut compiler = SakuraCompiler::new();
+        compiler.compile("o4c");
+        let second = compiler.compile("o4d");
+        let dump = compiler.dump_midi(second);
+
+        assert_eq!(dump.matches("NoteOn(").count(), 1);
+        assert!(dump.contains("NoteOn($32"));
+        assert!(!dump.contains("NoteOn($30"));
+    }
+
+    #[test]
+    fn compiler_rejects_only_inputs_over_the_configured_limit() {
+        let mut compiler = SakuraCompiler::new();
+        compiler.set_max_input_size(2);
+
+        assert!(compiler.compile("cc").starts_with(b"MThd"));
+        assert!(compiler.compile("ccc").is_empty());
+        assert!(compiler.get_log().contains("Input size exceeds max_input_size (3 > 2)"));
+    }
+
+    #[test]
+    fn malformed_mml_does_not_panic() {
+        for source in ["Tempo()", "TimeSig()", "SysEx()", "[", "Function F(){"] {
+            let result = std::panic::catch_unwind(|| compile(source, SAKURA_DEBUG_NONE));
+            assert!(result.is_ok(), "次の入力でパニックしました: {source:?}");
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,11 @@ fn main() {
         }
         else if arg == "--eval" || arg == "-e" || arg == "eval" || arg == "e" {
             i += 1;
-            eval_mml = if i < args.len() { String::from(&args[i]) } else { String::new() };
+            if i >= args.len() {
+                eprintln!("[ERROR](0): --eval requires MML text");
+                std::process::exit(1);
+            }
+            eval_mml = String::from(&args[i]);
             outfile = String::from("eval.mid");
         }
         else if arg == "--dump" || arg == "dump" || arg == "-m" {
@@ -106,7 +110,7 @@ fn main() {
             },
             Err(_e) => {
                 println!("[ERROR](0): File not found : {}", filename);
-                return;
+                std::process::exit(1);
             }
         }
     }
@@ -119,7 +123,7 @@ fn main() {
             Ok(s) => s,
             Err(_e) => {
                 println!("[ERROR](0): File not found : {}", filename);
-                return;
+                std::process::exit(1);
             }
         };
     }

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -87,7 +87,7 @@ fn generate_track(track: &Track) -> Vec<u8> {
                 timepos = e.time;
                 res.push(e.v1 as u8);
                 res.push(e.v2 as u8);
-                res.push(e.v3 as u8);
+                array_push_delta(&mut res, e.v3);
                 let data = e.data.clone().unwrap();
                 for b in data.iter() {
                     res.push(*b);
@@ -103,7 +103,7 @@ fn generate_track(track: &Track) -> Vec<u8> {
                 // 1st byte must be 0xF0
                 res.push(0xF0); // SysEx Event
                 // 2nd byte must be length
-                res.push(size as u8);
+                array_push_delta(&mut res, size as isize);
                 // write data
                 for (i, b) in data.iter().enumerate() {
                     if i == 0 && *b == 0xF0 { continue; }
@@ -204,7 +204,14 @@ impl MidiReaderInfo {
 
 pub fn array_read_str(a: &Vec<u8>, pos: usize, len: usize) -> String {
     let mut s = String::new();
-    let sub_a = a[pos..pos+len].to_vec();
+    let end = match pos.checked_add(len) {
+        Some(end) => end,
+        None => return s,
+    };
+    let sub_a = match a.get(pos..end) {
+        Some(bytes) => bytes.to_vec(),
+        None => return s,
+    };
     match String::from_utf8(sub_a) {
         Ok(s) => s,
         Err(_) => {
@@ -245,7 +252,7 @@ pub fn array_readl_delta_time(a: &Vec<u8>, pos: &mut usize) -> usize {
     while *pos < a.len() {
         let cv = a[*pos] as usize;
         *pos += 1;
-        if cv < 0x7F {
+        if cv < 0x80 {
             v = v << 7 | cv;
             break;
         }
@@ -256,31 +263,57 @@ pub fn array_readl_delta_time(a: &Vec<u8>, pos: &mut usize) -> usize {
 
 pub fn dump_midi_event_meta(bin: &Vec<u8>, pos: &mut usize, info: &mut MidiReaderInfo) -> String {
     let p = *pos;
+    if bin.len().saturating_sub(p) < 2 {
+        *pos = bin.len();
+        return String::from("// [ERROR] Truncated MIDI meta event");
+    }
     let mtype = bin[p];
-    let meta_type = bin[p+1] as usize;
-    let meta_len = bin[p+2] as usize;
     match mtype {
         0xFF => {
+            let meta_type = bin[p+1] as usize;
+            let mut data_pos = p + 2;
+            let meta_len = array_readl_delta_time(bin, &mut data_pos);
+            let data_end = match data_pos.checked_add(meta_len) {
+                Some(end) if end <= bin.len() => end,
+                _ => {
+                    *pos = bin.len();
+                    return String::from("// [ERROR] Truncated MIDI meta event");
+                }
+            };
             let msg = match meta_type {
                 0x2F => { // end of track
                     info.is_eot = true;
                     String::from("/* __END_OF_TRACK__ */")
                 },
                 0x51 => { // tempo
+                    if meta_len < 3 {
+                        *pos = data_end;
+                        return String::from("// [ERROR] Truncated tempo event");
+                    }
                     // mpq = 60000000 / tempo || mpq * tempo = 60000000 || tempo = 60000000 / mpq
-                    let mpq = (bin[p+3] as usize) << 16  | (bin[p+4] as usize) << 8 | bin[p+5] as usize;
+                    let mpq = (bin[data_pos] as usize) << 16
+                        | (bin[data_pos+1] as usize) << 8
+                        | bin[data_pos+2] as usize;
+                    if mpq == 0 {
+                        *pos = data_end;
+                        return String::from("// [ERROR] Tempo value is zero");
+                    }
                     let tempo = 60000000 / mpq;
                     format!("Tempo={}", tempo)
                 },
                 0x58 => { // TimeSig
-                    let nn = bin[p + 3] as usize;
-                    let dd = bin[p + 4] as usize;
+                    if meta_len < 2 {
+                        *pos = data_end;
+                        return String::from("// [ERROR] Truncated time-signature event");
+                    }
+                    let nn = bin[data_pos] as usize;
+                    let dd = bin[data_pos + 1] as usize;
                     info.frac = nn;
                     info.deno = (2i32.pow(dd as u32)) as usize;
                     format!("TimeSig={}/{}", info.frac, info.deno)
                 },
                 _ => { // text
-                    let txt = array_read_str(bin, p+3, meta_len);
+                    let txt = array_read_str(bin, data_pos, meta_len);
                     let meta_name = match meta_type {
                         0x01 => { "TEXT".to_string() },
                         0x02 => { "COPYRIGHT".to_string() },
@@ -294,33 +327,31 @@ pub fn dump_midi_event_meta(bin: &Vec<u8>, pos: &mut usize, info: &mut MidiReade
                     format!("{}{{{}}};", meta_name, txt)
                 }
             };
-            *pos += 3 + meta_len;
+            *pos = data_end;
             msg
         },
         0xF0 => { // SysEx = 0xF0 ... 0xF7
-            let mut m = String::new();
-            let mut index = 0;
-            while *pos < bin.len() {
-                let b = bin[*pos];
-                if index == 1 { // SysExの2バイト目はSysExの長さを表す
-                    m.push_str(&format!("/*len:{:02X}*/", b));
-                } else {
-                    m.push_str(&format!("{:02X}", b));
-                    if b != 0xf7 {
-                        m.push(',');
-                    }
+            let mut data_pos = p + 1;
+            let data_len = array_readl_delta_time(bin, &mut data_pos);
+            let data_end = match data_pos.checked_add(data_len) {
+                Some(end) if end <= bin.len() => end,
+                _ => {
+                    *pos = bin.len();
+                    return String::from("// [ERROR] Truncated SysEx event");
                 }
-                if bin[*pos] == 0xf7 {
-                    *pos += 1;
-                    break;
+            };
+            let mut m = format!("F0,/*len:{:02X}*/", data_len);
+            for (index, b) in bin[data_pos..data_end].iter().enumerate() {
+                m.push_str(&format!("{:02X}", b));
+                if index + 1 < data_len {
+                    m.push(',');
                 }
-                *pos += 1;
-                index += 1;
             }
+            *pos = data_end;
             format!("SysEx$={};", m)
         },
         _ => {
-            format!("// [ERROR] Unknown meta event...={:02x}", meta_type)
+            format!("// [ERROR] Unknown meta event...={:02x}", mtype)
         }
     }
 }
@@ -347,8 +378,20 @@ pub fn note_no_dec(no: u8) -> String {
 }
 
 pub fn dump_midi_event(bin: &Vec<u8>, pos: &mut usize, info: &mut MidiReaderInfo) -> String {
+    if *pos >= bin.len() {
+        return String::from("// [ERROR] Truncated MIDI event");
+    }
     let p = *pos;
     let event_type = bin[p] & 0xF0;
+    let required_len = match event_type {
+        0x80 | 0x90 | 0xA0 | 0xB0 | 0xE0 => 3,
+        0xC0 | 0xD0 => 2,
+        _ => 1,
+    };
+    if bin.len().saturating_sub(p) < required_len {
+        *pos = bin.len();
+        return String::from("// [ERROR] Truncated MIDI event");
+    }
     match event_type {
         0x80 => { // note on
             let msg = format!("NoteOff(${:02x},${:02x}) // {}", bin[p+1], bin[p+2], note_no_dec(bin[p+1]));
@@ -406,6 +449,10 @@ pub fn dump_midi(bin: &Vec<u8>, flag_stdout: bool) -> String {
         res.push('\n');
         if flag_stdout { println!("{}", s); }
     };
+    if bin.len() < 14 {
+        log("[ERROR] Truncated MIDI header");
+        return res;
+    }
     let mut pos = 0;
     let s = array_read_str(bin, pos, 4);
     if s != "MThd" {
@@ -437,6 +484,10 @@ pub fn dump_midi(bin: &Vec<u8>, flag_stdout: bool) -> String {
     for no in 0..track_count {
         log(&format!("// ----- TRACK -----"));
         log(&format!("TRACK({})", no));
+        if bin.len().saturating_sub(pos) < 8 {
+            log("// [ERROR] Truncated MIDI track header");
+            return res;
+        }
         let mtrk = array_read_str(bin, pos, 4);
         if mtrk != "MTrk" {
             log(&format!("// [ERROR] Track header broken MTrk!={}", mtrk));
@@ -448,9 +499,19 @@ pub fn dump_midi(bin: &Vec<u8>, flag_stdout: bool) -> String {
         pos += 4;
         let mut time = 0;
         // loop track
-        let end_pos = pos + mtrk_size as usize;
-        while pos < end_pos || !info.is_eot {
+        let end_pos = match pos.checked_add(mtrk_size as usize) {
+            Some(end_pos) if end_pos <= bin.len() => end_pos,
+            _ => {
+                log("// [ERROR] MIDI track size exceeds input data");
+                return res;
+            }
+        };
+        while pos < end_pos && !info.is_eot {
             let delta_time = array_readl_delta_time(bin, &mut pos);
+            if pos >= end_pos {
+                log("// [ERROR] Truncated MIDI event");
+                return res;
+            }
             time += delta_time;
             let beat_base = (timebase as f32 * 4.0 / info.deno as f32) as usize;
             let beat_base = if beat_base == 0 { timebase } else { beat_base }; // for divisor of zero
@@ -462,6 +523,10 @@ pub fn dump_midi(bin: &Vec<u8>, flag_stdout: bool) -> String {
             let desc = dump_midi_event(bin, &mut pos, &mut info);
             // log(&format!("{:5}|TIME({:03}:{:03}:{:03}) {}", time, mes, beat, tick, desc));
             log(&format!("TIME({:03}:{:03}:{:03}) {}", mes, beat, tick, desc));
+        }
+        if !info.is_eot {
+            log("// [ERROR] MIDI track has no end-of-track event");
+            return res;
         }
         info.is_eot = false;
     }
@@ -492,5 +557,50 @@ mod tests {
         assert_eq!(res[0], 0x83);
         assert_eq!(res[1], 0xFF);
         assert_eq!(res[2], 0x7F);
+    }
+
+    #[test]
+    fn delta_time_round_trips_at_variable_length_boundaries() {
+        for value in [0, 1, 126, 127, 128, 16_383, 16_384, 0x0FFF_FFFF] {
+            let mut encoded = vec![];
+            array_push_delta(&mut encoded, value);
+            let mut pos = 0;
+            assert_eq!(array_readl_delta_time(&encoded, &mut pos), value as usize);
+            assert_eq!(pos, encoded.len());
+        }
+    }
+
+    #[test]
+    fn dump_midi_rejects_truncated_data_without_panicking() {
+        let cases = [
+            vec![],
+            b"MTh".to_vec(),
+            b"MThd\0\0\0\x06".to_vec(),
+            b"MThd\0\0\0\x06\0\x01\0\x01\0\x60MTrk\0\0\0\x10\0".to_vec(),
+        ];
+
+        for bin in cases {
+            let result = std::panic::catch_unwind(|| dump_midi(&bin, false));
+            assert!(result.is_ok(), "次のMIDIデータでパニックしました: {bin:02X?}");
+            assert!(result.unwrap().contains("ERROR"));
+        }
+    }
+
+    #[test]
+    fn long_meta_text_uses_a_variable_length_size() {
+        let text = "a".repeat(140);
+        let mut song = Song::new();
+        song.add_event(crate::song::Event::meta(
+            0,
+            0xFF,
+            0x01,
+            text.len() as isize,
+            text.clone().into_bytes(),
+        ));
+        let bin = generate(&mut song);
+
+        let dump = dump_midi(&bin, false);
+        assert!(dump.contains(&format!("TEXT{{{text}}}")), "{dump}");
+        assert!(bin.windows(4).any(|bytes| bytes == [0xFF, 0x01, 0x81, 0x0C]));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -330,6 +330,7 @@ pub fn exec(song: &mut Song, tokens: &Vec<Token>) -> bool {
                 let args = exec_args(song, &t.children.clone().unwrap_or(vec![]));
                 if args.len() < 2 {
                     runtime_error(song, "[TimeSignature] argument must be 2");
+                    pos += 1;
                     continue;
                 }
                 song.timesig_frac = value_range(2, args[0].to_i(), 64);
@@ -365,6 +366,7 @@ pub fn exec(song: &mut Song, tokens: &Vec<Token>) -> bool {
                 let mut args: Vec<SValue> = exec_args(song, &t.children.clone().unwrap_or(vec![]));
                 if args.len() == 0 {
                     runtime_error(song, &format!("SysEx : {}", song.get_message(MessageKind::ErrorWrongArguments)));
+                    pos += 1;
                     continue;
                 }
                 // check leading 0xF0
@@ -571,7 +573,7 @@ pub fn exec(song: &mut Song, tokens: &Vec<Token>) -> bool {
             TokenType::TrackKey => trk!(song).track_key = exec_value_int_by_token(song, t),
             TokenType::DefInt => {
                 match &t.value_s {
-                    None => { runtime_error(song, "[SYSTEM ERROR][DefInt] variable name is empty"); continue; },
+                    None => { runtime_error(song, "[SYSTEM ERROR][DefInt] variable name is empty"); pos += 1; continue; },
                     Some(var_name) => {
                         let val = exec_value(song, &t.children.clone().unwrap_or(vec![]));
                         if val.is_array() {
@@ -586,7 +588,7 @@ pub fn exec(song: &mut Song, tokens: &Vec<Token>) -> bool {
             },
             TokenType::DefStr => {
                 match &t.value_s {
-                    None => { runtime_error(song, "[SYSTEM ERROR][DefStr] variable name is empty"); continue; },
+                    None => { runtime_error(song, "[SYSTEM ERROR][DefStr] variable name is empty"); pos += 1; continue; },
                     Some(var_name) => {
                         let val = exec_value(song, &t.children.clone().unwrap_or(vec![]));
                         song.variables_insert(var_name, val);
@@ -595,7 +597,7 @@ pub fn exec(song: &mut Song, tokens: &Vec<Token>) -> bool {
             },
             TokenType::DefArray => {
                 match &t.value_s {
-                    None => { runtime_error(song, "[SYSTEM ERROR][DefArray] variable name is empty"); continue; },
+                    None => { runtime_error(song, "[SYSTEM ERROR][DefArray] variable name is empty"); pos += 1; continue; },
                     Some(var_name) => {
                         let val = exec_value(song, &t.children.clone().unwrap_or(vec![]));
                         song.variables_insert(var_name, val);
@@ -606,6 +608,7 @@ pub fn exec(song: &mut Song, tokens: &Vec<Token>) -> bool {
                 match &t.value_s {
                     None => {
                         runtime_error(song, "[SYSTEM ERROR][GetVariable] variable name is empty");
+                        pos += 1;
                         continue;
                     },
                     Some(var_name) => {
@@ -873,6 +876,7 @@ pub fn exec(song: &mut Song, tokens: &Vec<Token>) -> bool {
                 match &t.children {
                     None => {
                         song.stack.push(SValue::Array(vec![]));
+                        pos += 1;
                         continue;
                     },
                     Some(tokens) => {

--- a/src/runner_test.rs
+++ b/src/runner_test.rs
@@ -205,6 +205,12 @@ mod test_for_runner {
         // mid
         let song = exec_easy("STR A={abcd};PRINT(MID(A,1,2))");
         assert_eq!(song.get_logs_str(), "[PRINT](0) ab");
+        // 文字位置はUTF-8のバイト位置ではなく文字単位で扱う
+        let song = exec_easy("STR A={あいうえ};PRINT(MID(A,2,2))");
+        assert_eq!(song.get_logs_str(), "[PRINT](0) いう");
+        // 範囲外や負数を指定してもパニックしない
+        let song = exec_easy("STR A={abc};PRINT(MID(A,99,2));PRINT(MID(A,-1,2))");
+        assert_eq!(song.get_logs_str(), "[PRINT](0) \n[PRINT](0) ab");
     }
     #[test]
     fn test_exec_sys_func_replace() {

--- a/src/sakura_functions.rs
+++ b/src/sakura_functions.rs
@@ -8,12 +8,17 @@ pub type CallbackCalcFn = fn (&mut Song, Vec<SValue>) -> SValue;
 pub fn calc_randomint(song: &mut Song, args: Vec<SValue>) -> SValue {
     let arg_count = args.len();
     if arg_count >= 2 {
-        let min = args[0].to_i();
-        let max = args[1].to_i();
+        let a = args[0].to_i();
+        let b = args[1].to_i();
+        let min = a.min(b);
+        let max = a.max(b);
         let rnd = (song.rand() & 0x7FFFFFFF) as isize % (max - min + 1) + min;
         SValue::from_i(rnd)
     } else if arg_count == 1 {
         let m = args[0].to_i();
+        if m <= 0 {
+            return SValue::from_i(0);
+        }
         let v = ((song.rand() & 0x7FFFFFFF) as isize) % m;
         SValue::from_i(v)
     } else {
@@ -25,6 +30,9 @@ pub fn calc_randomint(song: &mut Song, args: Vec<SValue>) -> SValue {
 /// RandomSelect
 pub fn calc_random_select(song: &mut Song, args: Vec<SValue>) -> SValue {
     let arg_count = args.len();
+    if arg_count == 0 {
+        return SValue::None;
+    }
     /*
     if arg_count == 1 {
         let a = args[0].to_array();
@@ -50,12 +58,12 @@ pub fn calc_chr(_: &mut Song, args: Vec<SValue>) -> SValue {
 }
 
 // mid function
-fn vb_mid(input: &str, start: usize, length: usize) -> Option<&str> {
-    let input_len = input.len();
-    let start = if start >= 1 { start - 1 } else { 0 };
-    let mut end = start + length;
-    if end >= input_len { end = input_len; }
-    Some(&input[start..end])
+fn vb_mid(input: &str, start: isize, length: isize) -> String {
+    if length <= 0 {
+        return String::new();
+    }
+    let start = start.max(1) as usize - 1;
+    input.chars().skip(start).take(length as usize).collect()
 }
 
 /// Mid
@@ -63,10 +71,9 @@ pub fn calc_mid(_: &mut Song, args: Vec<SValue>) -> SValue {
     let arg_count = args.len();
     if arg_count >= 3 {
         let val = args[0].to_s();
-        let i_from = args[1].to_i() as usize;
-        let i_len = args[2].to_i() as usize;
-        let s = vb_mid(&val, i_from, i_len).unwrap_or("");
-        SValue::from_str(s)
+        let i_from = args[1].to_i();
+        let i_len = args[2].to_i();
+        SValue::from_s(vb_mid(&val, i_from, i_len))
     } else {
         SValue::from_str("(MID:ERROR)")
     }
@@ -184,4 +191,41 @@ pub fn calc_pos(_: &mut Song, args: Vec<SValue>) -> SValue {
         return SValue::from_i((prefix.chars().count() + 1) as isize);
     }
     SValue::from_i(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn random_functions_handle_empty_or_invalid_ranges() {
+        let mut song = Song::new();
+        assert_eq!(calc_randomint(&mut song, vec![SValue::from_i(0)]).to_i(), 0);
+        assert!(calc_random_select(&mut song, vec![]).is_none());
+
+        for _ in 0..8 {
+            let value = calc_randomint(
+                &mut song,
+                vec![SValue::from_i(5), SValue::from_i(3)],
+            ).to_i();
+            assert!((3..=5).contains(&value));
+        }
+    }
+
+    #[test]
+    fn string_functions_support_unicode_character_positions() {
+        let mut song = Song::new();
+        let mid = calc_mid(
+            &mut song,
+            vec![SValue::from_str("あいうえ"), SValue::from_i(2), SValue::from_i(2)],
+        );
+        assert_eq!(mid.to_s(), "いう");
+        assert_eq!(
+            calc_pos(
+                &mut song,
+                vec![SValue::from_str("う"), SValue::from_str("あいうえ")],
+            ).to_i(),
+            3,
+        );
+    }
 }

--- a/src/song_test.rs
+++ b/src/song_test.rs
@@ -103,4 +103,57 @@ mod note_tests {
         // TODO: 引数の省略 (#37)
         // assert_eq!(&test_mml_log("FUNCTION ADD(INT A, INT B=0){ PRINT(A+B) }; ADD(3)"), "3"); // 値の省略
     }
+
+    #[test]
+    fn normalize_adds_note_off_before_the_next_note_at_the_same_time() {
+        let mut track = Track::new(96, 0);
+        track.events.push(Event::note(0, 0, 60, 96, 100));
+        track.events.push(Event::note(96, 0, 62, 96, 100));
+
+        track.normalize();
+        track.events_sort();
+
+        assert_eq!(track.events.len(), 4);
+        assert_eq!(track.events[1].time, 96);
+        assert_eq!(track.events[1].etype, EventType::NoteOff);
+        assert_eq!(track.events[2].time, 96);
+        assert_eq!(track.events[2].etype, EventType::NoteOn);
+    }
+
+    #[test]
+    fn play_from_restores_voice_and_control_change() {
+        let mut track = Track::new(96, 2);
+        track.events.push(Event::voice(0, 2, 10));
+        track.events.push(Event::cc(24, 2, 7, 80));
+        track.events.push(Event::note(40, 2, 60, 24, 100));
+        track.events.push(Event::note(72, 2, 62, 24, 100));
+
+        track.play_from(48);
+
+        assert!(track.events.iter().any(|e|
+            e.etype == EventType::Voice && e.time == 0 && e.channel == 2 && e.v1 == 10));
+        assert!(track.events.iter().any(|e|
+            e.etype == EventType::ControllChange && e.time == 0 && e.v1 == 7 && e.v2 == 80));
+        let notes: Vec<_> = track.events.iter()
+            .filter(|e| e.etype == EventType::NoteOn)
+            .collect();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].time, 24);
+        assert_eq!(notes[0].v1, 62);
+    }
+
+    #[test]
+    fn on_note_values_stop_or_cycle_as_configured() {
+        let mut track = Track::new(96, 0);
+        track.v_on_note = Some(vec![10, 20]);
+        assert_eq!(track.calc_v_on_note(99), 10);
+        assert_eq!(track.calc_v_on_note(99), 20);
+        assert_eq!(track.calc_v_on_note(99), 99);
+
+        track.v_on_note = Some(vec![30, 40]);
+        track.v_on_note_is_cycle = true;
+        assert_eq!(track.calc_v_on_note(99), 30);
+        assert_eq!(track.calc_v_on_note(99), 40);
+        assert_eq!(track.calc_v_on_note(99), 30);
+    }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,0 +1,94 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new(name: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("現在時刻を取得できません")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("sakuramml-{name}-{}-{unique}", std::process::id()));
+        fs::create_dir(&path).expect("テスト用ディレクトリを作成できません");
+        Self(path)
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn run(args: &[&str], current_dir: &TestDir) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_sakuramml"))
+        .args(args)
+        .current_dir(&current_dir.0)
+        .output()
+        .expect("sakurammlを実行できません")
+}
+
+#[test]
+fn help_and_version_succeed() {
+    let dir = TestDir::new("help");
+    let help = run(&["--help"], &dir);
+    assert!(help.status.success());
+    assert!(String::from_utf8_lossy(&help.stdout).contains("USAGE:"));
+
+    let version = run(&["--version"], &dir);
+    assert!(version.status.success());
+    assert!(!String::from_utf8_lossy(&version.stdout).trim().is_empty());
+}
+
+#[test]
+fn eval_creates_a_midi_file() {
+    let dir = TestDir::new("eval");
+    let output = run(&["--eval", "o4c"], &dir);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("ok."));
+    assert!(fs::read(dir.0.join("eval.mid"))
+        .unwrap()
+        .starts_with(b"MThd"));
+}
+
+#[test]
+fn input_file_uses_mid_as_the_default_extension() {
+    let dir = TestDir::new("file");
+    fs::write(dir.0.join("song.mml"), "o4c").unwrap();
+
+    let output = run(&["song.mml"], &dir);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(fs::read(dir.0.join("song.mid"))
+        .unwrap()
+        .starts_with(b"MThd"));
+}
+
+#[test]
+fn missing_input_file_reports_an_error() {
+    let dir = TestDir::new("missing");
+    let output = run(&["missing.mml"], &dir);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("File not found"));
+    assert!(!dir.0.join("missing.mid").exists());
+}
+
+#[test]
+fn eval_without_source_reports_an_error() {
+    let dir = TestDir::new("eval-missing");
+    let output = run(&["--eval"], &dir);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires MML text"));
+    assert!(!dir.0.join("eval.mid").exists());
+}


### PR DESCRIPTION
## 概要

不足していた重要テストを17件追加し、テストで再現した安全性・境界値の問題を修正します。

## 変更内容

- 公開コンパイラAPIの再利用、入力上限、不正MMLをテスト
- MIDI可変長数値、破損データ、長いMetaイベントをテスト
- 日本語文字列の `MID` と不正な乱数引数をテスト
- NoteOff順序、途中再生、`.onNote` の状態遷移をテスト
- CLIのhelp/version、ファイル変換、`--eval`、エラー終了を統合テスト

## 修正した問題

- コンパイラ再利用時に前回の曲とログが混入する
- `TimeSig()` と空の `SysEx()` で実行位置が進まず無限ループする
- 日本語文字列の `MID` と不正な乱数引数でパニックする
- 短いMIDI入力で範囲外参照する
- MIDI可変長数値の `0x7F` 境界と長いMeta/SysExの長さ処理
- CLIエラーが成功終了になる

## 影響

通常のMML/MIDI出力は既存ゴールデンテストで不変を確認しています。異常入力時はパニックや無限ループを避け、CLIはエラー終了コードを返します。

## 検証

- `cargo test -q`（102件成功、失敗0）
- 既存ゴールデンテスト（2件成功）
- `git diff --check`