### PR TITLE
make doc がmml_def分割後も動くようスクリプトを修正 #75

### DIFF
--- a/src/batch_extract_command.nako3
+++ b/src/batch_extract_command.nako3
@@ -5,6 +5,16 @@ SCRIPT_DIR=母艦パス
 ROOT_DIR=SCRIPT_DIRからパス抽出
 「ROOT=」&ROOT_DIRを表示
 # ------------------------------------------
+# 抽出結果が空ならエラーにする。
+# ソースをモジュール分割してマーカーの在り処が変わったとき、
+# 空のcommand.mdを黙って生成してしまうのを防ぐ。
+# ------------------------------------------
+●(SをNで)抽出検査処理とは
+　　もし、S=「」ならば、
+　　　　「[ERROR] {N} の抽出結果が空です。参照先のファイルとマーカーを確認してください。」でエラー発生。
+　　ここまで。
+ここまで。
+# ------------------------------------------
 RES=""
 # ------------------------------------------
 # lexer.rs
@@ -54,16 +64,17 @@ S_LISTを改行で区切って反復
 　　SSS＝SSSの「|」を「/」に置換。
 　　R=R&「| {S名前} | {SSS} |」&改行
 ここまで。
+RES_SUTOTON_RAW=R
 RES_SUTOTON=「
 | ストトン表記 | 説明 (=定義) |
 | ---------|---------|
 {R}
 」
 # ------------------------------------------
-# 音色 - mml_def.rs
+# 音色 - mml_def/variables.rs
 # ------------------------------------------
 RES=""
-L=「{SCRIPT_DIR}/mml_def.rs」を開く。
+L=「{SCRIPT_DIR}/mml_def/variables.rs」を開く。
 Lの「<VARIABLES>」から「</VARIABLES>」まで範囲切り取って、S_LISTに代入。
 S_LISTを改行で区切って反復
 　　対象を『/"(.+?)".*\((\d+|\".+?\").*\/\/ \@(.+?)$/』で正規表現マッチ。
@@ -75,7 +86,10 @@ S_LISTを改行で区切って反復
 ここまで。
 RES_VOICE=RES
 # ------------------------------------------
+# リズムマクロ - mml_def/rhythm.rs
+# ------------------------------------------
 RES=""
+L=「{SCRIPT_DIR}/mml_def/rhythm.rs」を開く。
 Lの「<RHYTHM_MACRO>」から「</RHYTHM_MACRO>」を範囲切り取る。S_LISTに代入。
 S_LISTを改行で区切って反復
 　　対象を『/'(.)'.*:from\((".+?")/』で正規表現マッチ。
@@ -86,7 +100,10 @@ S_LISTを改行で区切って反復
 ここまで。
 RES_RHYTHM_MACRO=RES
 # ------------------------------------------
+# システム関数 - mml_def/system_functions.rs
+# ------------------------------------------
 RES=""
+L=「{SCRIPT_DIR}/mml_def/system_functions.rs」を開く。
 Lの「<SYSTEM_FUNCTION>」から「</SYSTEM_FUNCTION>」を範囲切り取る。S_LISTに代入。
 S_LISTを改行で区切って反復
 　　対象を『/"(.+)".*\/\/\s+(.*)/』で正規表現マッチ。
@@ -157,6 +174,18 @@ RES_REF=RES
 　　ここまで。
 　　ＲＥＳを戻す。
 ここまで。
+
+# ------------------------------------------
+# 抽出結果の検査
+# ------------------------------------------
+RES_1CHARを「<CHAR_COMMANDS> (src/lexer.rs)」で抽出検査処理。
+RES_UPを「<SYSTEM_FUNCTION> (src/mml_def/system_functions.rs)」で抽出検査処理。
+SYSTEM_CALC_FUNCTIONを「<SYSTEM_CALC_FUNCTION> (src/mml_def/system_functions.rs)」で抽出検査処理。
+RES_REFを「<SYSTEM_REF> (src/runner.rs)」で抽出検査処理。
+RES_VOICEを「<VARIABLES> (src/mml_def/variables.rs)」で抽出検査処理。
+RES_RHYTHM_MACROを「<RHYTHM_MACRO> (src/mml_def/rhythm.rs)」で抽出検査処理。
+RES_SUTOTON_RAWを「<SUTOTON> (src/sutoton.rs)」で抽出検査処理。
+「--- 抽出検査: 全セクションOK ---」と表示。
 
 MD=「
 # Sakuramml command list - テキスト音楽 サクラ


### PR DESCRIPTION
## 概要

#95 で `mml_def.rs` をサブモジュールへ分割した際、`src/batch_extract_command.nako3` の参照先を更新していませんでした。**私の見落としによるリグレッションです。**

`make doc` を実行すると `command.md` の以下のセクションが**空のまま生成される**状態になっていました。

| セクション | マーカー |
|---|---|
| Multiple-character command | `<SYSTEM_FUNCTION>` |
| Function usable within an expression | `<SYSTEM_CALC_FUNCTION>` |
| Macro and Voice List | `<VARIABLES>` |
| Rhythm macro | `<RHYTHM_MACRO>` |

コミット済みの `command.md` 自体は無事です（#95 では再生成していないため）。壊れていたのは**再生成の経路だけ**です。

## 修正内容

### 1. 参照先の修正

| マーカー | 修正後の参照先 |
|---|---|
| `<VARIABLES>` | `src/mml_def/variables.rs` |
| `<RHYTHM_MACRO>` | `src/mml_def/rhythm.rs` |
| `<SYSTEM_FUNCTION>` | `src/mml_def/system_functions.rs` |
| `<SYSTEM_CALC_FUNCTION>` | `src/mml_def/system_functions.rs` |

`<CHAR_COMMANDS>` (src/lexer.rs)、`<SYSTEM_REF>` (src/runner.rs)、`<SUTOTON>` (src/sutoton.rs) は移動していないため変更ありません。

### 2. 抽出検査処理の追加

同じ事故が二度と起きないよう、抽出結果が空のセクションを検知してエラーで停止する処理を追加しました。今回の不具合は**黙って空のテーブルを出力していた**ため気付けなかったので、それを防ぎます。

```
[実行時エラー]batch_extract_command.nako3(14行目): [ERROR] <VARIABLES> (src/mml_def/variables.rs) の抽出結果が空です。参照先のファイルとマーカーを確認してください。
```

エラー時は `command.md` を書き出さずに終了するため、壊れたドキュメントで上書きされることもありません（実際に参照先を壊して動作確認済み）。

## 検証

- リファクタ前 (`ec733bc`) のソースから生成した `command.md` と、本PR適用後に生成した `command.md` が**バイト単位で完全一致**することを確認
- 意図的に参照先を分割前のパスへ戻して、検査処理がエラーを出し `command.md` が上書きされないことを確認

## 補足: runner の分割が main に入っていません

調査中に気付いた別件です。#94 (runner.rs の分割) は `main` ではなく中間ブランチ `claude/sakuramml-rust-refactor-plan-147b7f` をベースに作成したため、そちらにマージされて **main には反映されていません** (`src/runner/` が存在しない)。改めて main 向けのPRを出す必要があります。

その際 `<SYSTEM_REF>` が `src/runner.rs` から `src/runner/function.rs` へ移動するので、本PRで追加した検査処理が検知します。同PRでスクリプトの参照先もあわせて更新します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)