### PR TITLE
PR #94 のレビュー指摘2件を修正 (#101 の再作成)

### DIFF
--- a/src/runner/cc.rs
+++ b/src/runner/cc.rs
@@ -39,9 +39,15 @@ pub(super) fn tempo_change_a_to_b(song: &mut Song, a: isize, b: isize, len: isiz
     trk!(song).timepos = timepos;
 }
 
+/// テンポの既定値(BPM)
+const DEFAULT_TEMPO: isize = 120;
+
 pub(super) fn tempo_change(song: &mut Song, tempo: isize) {
+    // TempoChange は Tempo と違い範囲チェックがないため 0 以下が渡り得る。
+    // そのままだと MIDI のテンポ(μsec/四分音符)が不正な値になるので既定値に戻す #94
+    let tempo = if tempo > 0 { tempo } else { DEFAULT_TEMPO };
     song.tempo = tempo;
-    let mpq = if tempo > 0 { 60000000 / tempo } else { 120 };
+    let mpq = 60000000 / tempo;
     let e = Event::meta(
         trk!(song).timepos,
         0xFF,

--- a/src/runner/function.rs
+++ b/src/runner/function.rs
@@ -103,7 +103,13 @@ pub(super) fn exec_sys_function(song: &mut Song, t: &Token) -> bool {
         song.stack.push(result);
     } else {
         // macro ("=var_name")
-        let func_name2 = if func_name.len() >= 2 { func_name[1..].to_string() } else { func_name };
+        // 先頭の '=' はマクロ呼び出しの印なので取り除く。
+        // 計算式由来の関数呼び出しには '=' が付かないため、
+        // 無条件に先頭1文字を落とすと別名の変数を参照してしまう #94
+        let func_name2 = match func_name.strip_prefix('=') {
+            Some(name) => name.to_string(),
+            None => func_name,
+        };
         let args = t.children.clone().unwrap_or(vec![]);
         let args = exec_args(song, &args);
         let val = song.variables_get(&func_name2).unwrap_or(&SValue::new()).clone();

--- a/src/runner_test.rs
+++ b/src/runner_test.rs
@@ -350,3 +350,30 @@ mod test_for_runner {
     }
 }
 // ------------------------------------------
+
+#[cfg(test)]
+mod test_review_94 {
+    use super::exec_easy;
+    use crate::song::EventType;
+
+    #[test]
+    fn test_undefined_function_in_calc_keeps_name() {
+        // 計算式から未定義の関数を呼ぶと func_name に '=' が付かない。
+        // 先頭1文字を無条件に落とすと、別名の変数を参照してしまう。
+        // (修正前は FOO -> OO と解釈され 999 が返っていた)
+        let song = exec_easy("INT OO=999; PRINT(FOO(1))");
+        assert_eq!(song.get_logs_str(), "[PRINT](0) ");
+    }
+
+    #[test]
+    fn test_tempo_change_zero_writes_valid_mpq() {
+        // TempoChange は Tempo と違い範囲チェックがないため 0 が渡り得る。
+        // 0以下でも MIDI のテンポ(μsec/四分音符)として妥当な値を書くこと。
+        let song = exec_easy("TempoChange(0) c");
+        let e = song.tracks[0].events.iter()
+            .find(|e| e.etype == EventType::Meta && e.v2 == 0x51)
+            .expect("テンポのメタイベントがない");
+        // 既定の120BPM => 500000 usec => 0x07A120
+        assert_eq!(e.data, Some(vec![0x07u8, 0xA1, 0x20]));
+    }
+}


### PR DESCRIPTION
Closes #99

PR #101 が main とコンフリクトしていたため、**未取り込みの修正コミット1件のみ**を現在の main に載せ直したPRです。#101 は本PRで置き換えられるためクローズしてください。

## #101 との差分

#101 の3コミットのうち2つは既に main に入っており、それがコンフリクトの原因でした。

| #101 のコミット | 本PRでの扱い |
|---|---|
| `96621f6` runner.rs を6つのサブモジュールに分割 | **除外** — PR #97 で `e331119` を cherry-pick済み |
| `2315a12` make doc の `<SYSTEM_REF>` 参照先を追従 | **除外** — PR #98 (`e8ec659`) が同じ箇所をより広範に修正済み。#101 側を適用すると `mml_def/*` へのパス追従と抽出検査処理が失われ退行します |
| `3033885` PR #94 のレビュー指摘2件を修正 | **これのみ採用** (コンフリクトなしで cherry-pick) |

## 修正内容 (`3033885` そのまま)

いずれも分割前から存在するバグで、再現テストを追加しています。

### 1. 未定義関数の呼び出しで別名の変数を参照してしまう (`src/runner/function.rs`)

マクロ呼び出し (`"=var_name"`) から `=` を取り除く処理が、先頭1文字を無条件に落としていました。計算式由来の関数呼び出しには `=` が付かないため、未定義関数が別名の変数として解決されていました。

```
Int OO = 999
Print(FOO(1))   // -> 999 が出力されていた (FOO が OO と解釈される)
```

`strip_prefix('=')` を使い、`=` で始まる場合だけ取り除くよう修正。

### 2. `TempoChange(0)` でMIDIのテンポが不正な値になる (`src/runner/cc.rs`)

`tempo <= 0` のとき `mpq` に `120` を代入していましたが、これは μsec/四分音符としては約50万BPM相当の不正な値です。`Tempo` は `value_range(10,,300)` でクランプされますが `TempoChange` には範囲チェックがなく 0 が渡り得ます。

```
TempoChange(0)  // [0x00,0x00,0x78] を書き出していた -> [0x07,0xA1,0x20] (120BPM)
```

0以下は既定値120BPMにフォールバックしてから `mpq` を計算するよう修正。`song.tempo` にも実効値を格納するため、`TempoChange(0)` 後の `Tempo` 参照値が 0 から 120 に変わります。

## 検証

- `cargo test` **104件通過** (新規テスト2件)
- ゴールデンMIDIのハッシュは変化なし

## 関連

- #99 (本PRで解消)
- #102 のうち **TempoChange の件は本PRで解決**します。`v__n` (sub velocity) の無限ループは未対応のため #102 は残ります
- #101 (本PRで置き換え / 要クローズ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)