### PR TITLE
MML関数で現在の演奏状態を取得できるようにする

### DIFF
--- a/docs/syntax-script.md
+++ b/docs/syntax-script.md
@@ -190,7 +190,7 @@ Print(Add(1, 2))    // 3
 | `Replace` | `Replace(S, A, B)` | 文字列Sの中のAをBに置き換える。別名 `REPLACE` |
 | `SizeOf` | `SizeOf(A)` | 配列の要素数を返す。別名 `SIZEOF` |
 | `StrLen` | `StrLen(S)` | 文字列の長さを返す。別名 `STRLEN` |
-| `MML` | `MML(C)` | `o` `v` `q` `t` `@` `BR` の現在値を返す |
+| `MML` | `MML(C)` | `l` `v` `o` `q` `t` `@` `BR` `p%` `Key` `TimeKey` `Port` の現在値を返す |
 | `Hex` | `Hex(V)` | 数値を16進文字列に変換する。別名 `HEX` |
 | `Pos` | `Pos(N, M)` | 文字列Mの中でNが現れる位置(1始まり)を返す。別名 `POS` |
 
@@ -201,6 +201,15 @@ Print(Replace({abc}, {a}, {b})) // bbc
 Print(Hex(255))                 // FF
 Print(Pos({b}, {abc}))          // 2
 Print(RandomSelect({c}, {d}, {e}))
+```
+
+`MML` の引数には、現在値を調べるMML命令名をそのまま指定します。`l` は内部のステップ数を返すため、既定の `TimeBase=96` では `l4` の値は `96` です。`p%` は中央を0とする詳細なピッチベンド値を返します。なお、現在のRust版では `TimeKey` 命令が未実装のため、`MML(TimeKey)` は初期値の `0` を返します。
+
+```
+l4 v100 o4
+Print(MML(l)) // 96
+Print(MML(v)) // 100
+Print(MML(o)) // 4
 ```
 
 ### 乱数の種

--- a/src/lexer/calc.rs
+++ b/src/lexer/calc.rs
@@ -127,7 +127,19 @@ pub(super) fn read_value_word(cur: &mut SourceCursor, song: &mut Song) -> Token 
         let arg_lineno = cur.line;
         let arg_str = cur.get_token_nest('(', ')');
         // println!("read_calc_args={:?}", arg_str);
-        let arg_tokens = lex_calc(song, &arg_str, arg_lineno);
+        // MML(l) などの引数は値ではなく、参照するMML命令名として渡す。
+        // 既知の命令名以外は従来どおり式として解析し、変数指定との互換性を保つ。
+        let arg_name = arg_str.trim();
+        let arg_tokens = if varname == "MML" && is_mml_state_name(arg_name) {
+            vec![Token::new_const(
+                TokenType::ConstStr,
+                arg_name.len() as isize,
+                Some(arg_name.to_string()),
+                TokenValueType::STR,
+            )]
+        } else {
+            lex_calc(song, &arg_str, arg_lineno)
+        };
         tok.children = Some(arg_tokens);
         tok.tag = 1; // FUNCTION
         tok.data.push(SValue::from_s(varname.clone()));
@@ -162,6 +174,23 @@ pub(super) fn read_value_word(cur: &mut SourceCursor, song: &mut Song) -> Token 
             return tok;
         }
     }
+}
+
+fn is_mml_state_name(name: &str) -> bool {
+    matches!(
+        name,
+        "l"
+            | "v"
+            | "o"
+            | "q"
+            | "t"
+            | "@"
+            | "BR"
+            | "p%"
+            | "Key"
+            | "TimeKey"
+            | "Port"
+    )
 }
 
 pub(super) fn is_operator_char(c: char) -> bool {

--- a/src/runner/cc.rs
+++ b/src/runner/cc.rs
@@ -5,6 +5,9 @@ pub(super) fn exec_cc_rpn_nrpn(song: &mut Song, t: &Token, cc1: isize, cc2: isiz
     let val = exec_value_int_by_token(song, t);
     let msb = t.data[0].to_i();
     let lsb = t.data[1].to_i();
+    if cc1 == 101 && cc2 == 100 && msb == 0 && lsb == 0 {
+        trk!(song).bend_range = val;
+    }
     song.add_event(Event::cc(trk!(song).timepos, trk!(song).channel, cc1, msb));
     song.add_event(Event::cc(trk!(song).timepos, trk!(song).channel, cc2, lsb));
     song.add_event(Event::cc(trk!(song).timepos, trk!(song).channel, cc3, val)); 
@@ -105,6 +108,7 @@ pub(super) fn exec_control_change(song: &mut Song, t: &Token) {
 /// ピッチベンドの送信
 pub(super) fn exec_pitch_bend(song: &mut Song, t: &Token) {
     let val = var_extract(&t.data[0], song).to_i();
+    trk!(song).pitch_bend = if t.value_i == 0 { val * 128 - 8192 } else { val };
     let val = if t.value_i == 0 { val * 128 } else { val + 8192 };
     song.add_event(Event::pitch_bend(
         trk!(song).timepos,

--- a/src/runner_test.rs
+++ b/src/runner_test.rs
@@ -308,6 +308,26 @@ mod test_for_runner {
         assert_eq!(song.get_logs_str(), "[PRINT](0) 6");
     }
     #[test]
+    fn test_mml_returns_current_track_and_song_values() {
+        let song = exec_easy(
+            "l4 v100 o4 q80 t-3 @25 BR(12) PitchBend(123) Key(2) Port(3)\
+             PRINT(MML(l)) PRINT(MML(v)) PRINT(MML(o)) PRINT(MML(q))\
+             PRINT(MML(t)) PRINT(MML(@)) PRINT(MML(BR)) PRINT(MML(p%))\
+             PRINT(MML(Key)) PRINT(MML(TimeKey)) PRINT(MML(Port))",
+        );
+        assert_eq!(
+            song.get_logs_str(),
+            "[PRINT](0) 96\n[PRINT](0) 100\n[PRINT](0) 4\n[PRINT](0) 80\n\
+             [PRINT](0) -3\n[PRINT](0) 25\n[PRINT](0) 12\n[PRINT](0) 123\n\
+             [PRINT](0) 2\n[PRINT](0) 0\n[PRINT](0) 3"
+        );
+    }
+    #[test]
+    fn test_mml_keeps_string_and_variable_arguments_compatible() {
+        let song = exec_easy("o6 STR Command={o} PRINT(MML({o})) PRINT(MML(Command))");
+        assert_eq!(song.get_logs_str(), "[PRINT](0) 6\n[PRINT](0) 6");
+    }
+    #[test]
     fn test_add_len() {
         // test basic
         let song = exec_easy("l4 c");

--- a/src/sakura_functions.rs
+++ b/src/sakura_functions.rs
@@ -143,6 +143,10 @@ pub fn calc_mml(song: &mut Song, args: Vec<SValue>) -> SValue {
     }
     let arg = &args[0];
     let sa = arg.to_s();
+    if sa == "l" {
+        let v = song.tracks[song.cur_track].length;
+        return SValue::from_i(v);
+    }
     if sa == "o" {
         let o = song.tracks[song.cur_track].octave;
         return SValue::from_i(o);
@@ -165,6 +169,21 @@ pub fn calc_mml(song: &mut Song, args: Vec<SValue>) -> SValue {
     }
     if sa == "BR" {
         let v = song.tracks[song.cur_track].bend_range;
+        return SValue::from_i(v);
+    }
+    if sa == "p%" {
+        let v = song.tracks[song.cur_track].pitch_bend;
+        return SValue::from_i(v);
+    }
+    if sa == "Key" {
+        return SValue::from_i(song.key_shift);
+    }
+    if sa == "TimeKey" {
+        // TimeKey命令は未実装のため、現在の時間キーは初期値の0。
+        return SValue::from_i(0);
+    }
+    if sa == "Port" {
+        let v = song.tracks[song.cur_track].port;
         return SValue::from_i(v);
     }
     SValue::from_i(0)

--- a/src/song/track.rs
+++ b/src/song/track.rs
@@ -58,6 +58,7 @@ pub struct Track {
     pub tie_mode: TieMode, // Slur(#7)
     pub tie_value: isize,
     pub bend_range: isize,
+    pub pitch_bend: isize,
     pub program_change: isize,
     pub v_on_time_start: isize,
     pub v_on_time: Option<Vec<isize>>,
@@ -128,6 +129,7 @@ impl Track {
             events: vec![],
             tie_notes: vec![],
             bend_range: -1,
+            pitch_bend: 0,
             cc_on_note: vec![],
             cc_on_note_wave: vec![],
         }


### PR DESCRIPTION
## 概要

Fixes #76

`MML(l)`、`MML(v)`、`MML(o)` などで、現在の演奏状態を取得できるようにします。

## 原因

`MML(l)` の引数 `l` が命令名として渡されず、先に現在の音長値へ評価されていました。そのため、`calc_mml` は数値を命令名として受け取り、未対応値として `0` を返していました。

## 変更内容

- `MML` の既知の引数を字句解析時に命令名として保持
- `l`、`v`、`o`、`q`、`t`、`@`、`BR`、`p%`、`Key`、`TimeKey`、`Port` の取得に対応
- ピッチベンド値とベンドレンジの現在値をトラック状態へ記録
- 既存の文字列引数・変数引数との互換性を維持
- 回帰テストと日本語ドキュメントを追加

Rust版では `TimeKey` 命令自体が未実装のため、`MML(TimeKey)` は現在の初期値 `0` を返します。

## 確認

- `cargo test`（全120テスト成功）
- `git diff --check`