### PR TITLE
Slur の第2引数に音長記法(!8 など)を使えるようにする

### DIFF
--- a/docs/syntax-note.md
+++ b/docs/syntax-note.md
@@ -285,9 +285,8 @@ Slur(モード[, 値])
 ```
 Slur(SLUR_BEND) c&d&e
 Slur(SLUR_GATE, 100) c&d&e      // 第2引数はモードに応じた値(SLUR_GATEならゲート値)
+Slur(SLUR_PORT, !8) c&d&e       // 第2引数には !8 のような音長表記も使える
 ```
-
-> `Slur` の引数に `!8` のような音長表記は使えません。数値で指定してください。
 
 ## 調号 `KeyFlag`
 

--- a/src/lexer/calc.rs
+++ b/src/lexer/calc.rs
@@ -100,6 +100,13 @@ pub(super) fn read_value(cur: &mut SourceCursor, song: &mut Song) -> Option<Toke
             let num = cur.get_int(0);
             return Some(Token::new_const(TokenType::ConstInt, num, None, TokenValueType::INT));
         },
+        '!' => {
+            // note length notation (e.g. !8, !4.)
+            cur.next(); // skip '!'
+            let len_str = cur.get_note_length();
+            let num = calc_length(&len_str, song.timebase, song.timebase);
+            return Some(Token::new_const(TokenType::ConstInt, num, None, TokenValueType::INT));
+        },
         '{' => {
             let str = cur.get_token_nest('{', '}');
             return Some(Token::new_const(TokenType::ConstStr, str.len() as isize, Some(str), TokenValueType::STR));

--- a/src/runner_test.rs
+++ b/src/runner_test.rs
@@ -777,8 +777,13 @@ mod test_issue_78 {
             .collect::<Vec<_>>();
         // ベロシティが既定値(100)のまま変化しないこと
         assert_eq!(notes[0].v3, 100);
-        // グリッサンド開始位置(!8 = 48ステップ)にピッチベンドが書き込まれること
+        // !8 が48ステップとして解釈され、数値で 48 と書いた場合と同じ結果になること
         let bends = pitch_bends(&song);
+        let expected = pitch_bends(&exec_easy("TimeBase=96 BR(2) Slur(0,48) l4 c&d"));
+        assert_eq!(bends, expected);
+        // グリッサンドは音符の48ステップ手前(96-48=48)から始まる。
+        // ただし開始時点のベンド値は0で直前の値と同じため出力されず、
+        // 最初に書き込まれるイベントは49ステップ目になる
         assert_eq!(bends.first().unwrap().0, 49);
     }
 }

--- a/src/runner_test.rs
+++ b/src/runner_test.rs
@@ -762,4 +762,23 @@ mod test_issue_78 {
         // タイの音符と次の音符で、2回分の波形が書き込まれる
         assert_eq!(bends.len(), 32 * 2);
     }
+
+    #[test]
+    fn test_slur_second_arg_accepts_note_length_notation() {
+        // Slur(type, value) の value に音長記法(!8)を書けること (#112)
+        // 以前は計算式パーサが "!" を比較演算子として扱っていたため解釈に失敗し、
+        // 残った文字が後続のコマンドとして読まれてベロシティが化けていた
+        let song = exec_easy("TimeBase=96 BR(2) Slur(0,!8) l4 c&d");
+        assert_eq!(song.get_logs_str(), "");
+        let notes = song.tracks[0]
+            .events
+            .iter()
+            .filter(|event| event.etype == EventType::NoteOn)
+            .collect::<Vec<_>>();
+        // ベロシティが既定値(100)のまま変化しないこと
+        assert_eq!(notes[0].v3, 100);
+        // グリッサンド開始位置(!8 = 48ステップ)にピッチベンドが書き込まれること
+        let bends = pitch_bends(&song);
+        assert_eq!(bends.first().unwrap().0, 49);
+    }
 }


### PR DESCRIPTION
## 概要

Issue #112 の修正です。`Slur(0,!8)` のように `Slur` コマンドの第2引数へ音長記法(`!8` など)を書くと、計算式パーサが `!` を比較演算子(`!=` の一部)としてしか扱えなかったため引数の解釈に失敗し、残った文字が後続コマンドとして読まれてベロシティが化けてしまう不具合を修正しました。

## 原因

`src/lexer/calc.rs` の `read_value` は値の先頭に現れる文字を判定していますが、`!` に対する処理がなく、`read_operator` 側でのみ比較演算子として扱われていました。そのため `Slur(0,!8)` の `!8` が値として読み取れず、`Missing Parenthesis` / `Unknown Character` エラーとともに、残ったトークンが後続コマンドとして誤読されていました。

## 修正内容

- `src/lexer/calc.rs`: `read_value` に `!` から始まる音長記法を読み取る処理を追加(`read_arg_value` と同様に `get_note_length()` + `calc_length()` でステップ数に変換)。`!=` などの比較演算子は `read_operator` 側の既存ロジックのままなので影響なし。
- `src/runner_test.rs`: `Slur(0,!8)` を指定してもベロシティが変化せず、指定したステップ数でグリッサンドが開始することを確認するテストを追加。
- `docs/syntax-note.md`: `Slur` の引数に音長表記が使えないという記述を、使える旨の記述に更新。

## 動作確認

```bash
cargo build --release
cargo test
./target/release/sakuramml --eval 'TR(1) BR(2) Slur(0,!8) l4 c&d' out.mid
./target/release/sakuramml -m out.mid   # エラーなし、ベロシティ100のまま、!8(48ステップ)でグリッサンド開始を確認
```

`Slur(2,!16)` のようなゲートモードでもエラーが出ないこと、`!=` を使う既存の条件式が引き続き正しく動作することも確認済みです。

## テスト

- [x] `cargo test`
- [x] `--eval` での再現手順(Issue記載のコマンド)で修正を確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>